### PR TITLE
Set ENABLE_SIM=OFF for all builds

### DIFF
--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -7,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -16,13 +14,13 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libboost_devel:
+- '1.82'
 ncurses:
 - '6'
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -40,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -42,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -42,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -42,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -42,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -42,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,7 +1,5 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -11,7 +9,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -20,13 +18,13 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libboost_devel:
+- '1.82'
 ncurses:
 - '6'
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -44,4 +42,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,5 +1,3 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - gcc
 c_compiler_version:
@@ -7,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -16,13 +14,13 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libboost_devel:
+- '1.82'
 ncurses:
 - '6'
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -40,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
 - '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libboost_devel:
+- '1.82'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:
@@ -21,8 +21,6 @@ ncurses:
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -40,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -38,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -1,19 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
-boost_cpp:
-- 1.78.0
 c_compiler:
 - clang
 c_compiler_version:
 - '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '15'
+libboost_devel:
+- '1.82'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:
@@ -21,8 +21,6 @@ ncurses:
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -40,4 +38,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -26,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.8.____cpythonpython_implcpython.yaml
@@ -26,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____73_pypypython_implpypy.yaml
@@ -26,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -26,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -26,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,18 +1,16 @@
-boost_cpp:
-- 1.78.0
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+libboost_devel:
+- '1.82'
 numpy:
 - '1.26'
 pin_run_as_build:
-  boost-cpp:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x
@@ -28,4 +26,3 @@ zip_keys:
 - - python
   - numpy
   - python_impl
-  - channel_sources

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -60,7 +60,7 @@ if [%python_impl%] == [pypy] (
     ^"
 ) else (
   set ^"CMAKE_OPTIONS=!CMAKE_OPTIONS! ^
-    -DENABLE_SIM=ON ^
+    -DENABLE_SIM=OFF ^
     ^"
 )
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,6 +39,7 @@ cmake_config_args=(
     -DENABLE_N300=ON
     -DENABLE_N320=ON
     -DENABLE_PYTHON_API=ON
+    -DENABLE_SIM=OFF
     -DENABLE_TESTS=OFF
     -DENABLE_UTILS=ON
     -DENABLE_USB=ON
@@ -54,11 +55,6 @@ if [[ $python_impl == "pypy" ]] ; then
         -DPYTHON_LIBRARY=$PREFIX/lib/`$PYTHON -c "import sysconfig; print(sysconfig.get_config_var('LDLIBRARY'))"`
         -DPYTHON_INCLUDE_DIR=`$PYTHON -c "import sysconfig; print(sysconfig.get_paths()['include'])"`
         -DUHD_PYTHON_DIR=$SP_DIR
-        -DENABLE_SIM=OFF
-    )
-else
-    cmake_config_args+=(
-        -DENABLE_SIM=ON
     )
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0006-lib-types-Declare-types-used-with-digital_filter_-ba.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('uhd', min_pin='x.x.x', max_pin='x.x.x') }}
   entry_points:   # [not linux]


### PR DESCRIPTION
Having this enabled makes libpython a dependency of libuhd, which almost doubles the size off the AppImage of Gqrx. Moreover, this apparently never even worked through conda-forge, because of missing Python dependencies that the simulator needs to run. Since nobody seems to be using this and it has a cost to enable, I'll disable it at least for now.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
